### PR TITLE
split up storage path into fragments

### DIFF
--- a/lib/StorageServer.php
+++ b/lib/StorageServer.php
@@ -84,10 +84,16 @@
 			if (!self::storageIdExists($storageId)) {
 				throw new \Exception("Storage does not exist");
 			}
+			if (is_dir(STORAGEBASE . "$storageId/")) { // backwards compatiblity check
+				$storagePath = $storageId;
+			} else {
+				$storagePath = implode("/", str_split($storageId, 4));
+			}
+
 			// The internal adapter
 			$adapter = new \League\Flysystem\Adapter\Local(
 				// Determine root directory
-				STORAGEBASE . "$storageId/"
+				STORAGEBASE . "$storagePath/"
 			);
 
 			$graph = new \EasyRdf\Graph();

--- a/lib/User.php
+++ b/lib/User.php
@@ -269,11 +269,13 @@
 		}
 
 		public static function getUserByWebId($webId) {
-			$idParts = explode(".", $webId, 2);
-			if ($idParts[1] !== BASEDOMAIN . "/#me") {
+			$webIdParts = parse_url($webId);
+			$idParts = explode(".", $webIdParts['host'], 2);
+			if ($idParts[1] !== BASEDOMAIN) {
 				return false;
 			}
-			$userId = preg_replace("/^id-/", "", $idParts[0]);
+			$userId = preg_replace("/^.*?id-/", "", $idParts[0]);
+
 			return self::getUserById($userId);
 		}
 


### PR DESCRIPTION
This prevents having a single directory with a million pods.

Also fixes an issue where the owner isn't looked up properly, which caused a 403 when fetching things from the storage.