### PR TITLE
Add Docker build and publish GitHub Worflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -49,6 +49,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          file: ./docker/solid.Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: "ghcr.io/${{ github.repository }}:${{ env.TAG }}"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - ci/docker-build
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,54 @@
+---
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - ci/docker-build
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push-image:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create docker tag (from git reference)
+        # A tag name may only contain lower- and uppercase letters, digits, underscores, periods and dashes.
+        run: |
+          echo "TAG=$(echo -n "${{ github.ref_name }}" \
+            | tr --complement --squeeze-repeats '[:alnum:]._-' '_')" \
+            >> "${GITHUB_ENV}"
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: "ghcr.io/${{ github.repository }}:${{ env.TAG }}"


### PR DESCRIPTION
This MR adds a GitHub Worflow that builds and publishes ("pushes") a docker image of this repository to the GitHub Container Registry (ghcr.io).

A docker image is created for each push to `main`, for each branch that has a merge-request to `main`, and for every git tag.

The docker image for this branch can be seen at: https://github.com/pdsinterop/multiuser-php-solid-server/pkgs/container/multiuser-php-solid-server/884546882?tag=ci_docker-build

This MR can be squashed, to avoid multiple commits.

 - - -
 
Some follow-up actions that come to mind:

- Add linting for the Dockerfile
- Change `tests/testsuite/run-solid-test-suite.sh` to pull the docker image from the registry, instead of building it (to reduce build time)
  https://github.com/pdsinterop/multiuser-php-solid-server/blob/c441e79942f254f55b05b949759c0b999b8887b4/tests/testsuite/run-solid-test-suite.sh#L9
- Add a `matrix` to build for other PHP versions than only 8.3

@ylebre Let me know if any of these (or something else) needs to be picked up. :+1: 