### PR TITLE
add route to fetch the current pod count

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -43,6 +43,10 @@
 
 	const PUBSUB_SERVER = "wss://pubsub:8080";
 
+	// Token / key that needs to be in the request to fetch the pod
+	// count from the storage api
+	const POD_COUNT_KEY = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
 	// Array of IPs that can be trusted. If they are in this list, they
 	// won't be locked out after failed login attempts;
 	const TRUSTED_IPS = [];

--- a/lib/Routes/SolidStorageProvider.php
+++ b/lib/Routes/SolidStorageProvider.php
@@ -31,5 +31,31 @@
 			header("Content-type: application/json");
 			echo json_encode($responseData, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
 		}
+
+		public static function respondToPodCount() {
+			$requestFactory = new ServerRequestFactory();
+			$rawRequest = $requestFactory->fromGlobals($_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
+
+			if (!defined('POD_COUNT_KEY')) {
+				header("HTTP/1.1 404 Not found");
+				exit();
+			}
+			if (!isset($_SERVER['HTTP_POD_COUNT_KEY'])) {
+				header("HTTP/1.1 404 Not found");
+				exit();
+			}
+			if ($_SERVER['HTTP_POD_COUNT_KEY'] !== POD_COUNT_KEY) {
+				header("HTTP/1.1 400 Bad Request");
+				exit();
+			}
+
+			$podCount = StorageServer::getPodCount();
+			$responseData = array(
+				"count" => $podCount
+			);
+			header("HTTP/1.1 200 OK");
+			header("Content-type: application/json");
+			echo json_encode($responseData, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+		}
 	}
 			

--- a/lib/StorageServer.php
+++ b/lib/StorageServer.php
@@ -48,6 +48,20 @@
 			];
 		}
 
+		public static function getPodCount() {
+			Db::connect();
+			$query = Db::$pdo->prepare(
+				'SELECT count(storage_id) as podCount FROM storage'
+			);
+			$query->execute();
+			$result = $query->fetchAll();
+
+			if (sizeof($result) === 1) {
+				return $result[0]['podCount'];
+			}
+			return false;
+		}
+
                 public static function storageIdExists($storageId) {
                         Db::connect();
                         $query = Db::$pdo->prepare(

--- a/www/storage/index.php
+++ b/www/storage/index.php
@@ -17,6 +17,10 @@
 	switch($method) {
 		case "GET":
 			switch ($request) {
+				case "/api/podcount":
+				case "/api/podcount/":
+					SolidStorageProvider::respondToPodCount();
+				break;
 				default:
 					header($_SERVER['SERVER_PROTOCOL'] . " 404 Not found");
 				break;


### PR DESCRIPTION
To fetch it, the request should pass a pod-count-key header that matches the POD_COUNT_KEY constant defined in the config.php;

The endpoint returns a {"count":xxx} json result which can then be used in all kinds of fun graph-things.

